### PR TITLE
[Fix] Benchmark dataset pipeline tweaks (zero impact on final results)

### DIFF
--- a/benchmark/dataset_pipeline/step2_make_lowh_file.py
+++ b/benchmark/dataset_pipeline/step2_make_lowh_file.py
@@ -429,7 +429,11 @@ def calc_mmseqs_seq_identity(
             shell=True,
             check=True,
         )
-        df = pd.read_csv(tmp_dir / "test_vs_train.tsv", sep="\t", header=None)
+        output_path = tmp_dir / "test_vs_train.tsv"
+        if output_path.stat().st_size == 0:
+            df = pd.DataFrame()
+        else:
+            df = pd.read_csv(output_path, sep="\t", header=None)
 
         for _, row in df.iterrows():
             query_id = row[0]
@@ -579,7 +583,7 @@ def make_lowh_parquet_file(
     )
 
     rna_test_vs_train = get_lowh_by_mmseqs_seq_identity(
-        df[df["entity_type"] == DNA],
+        df[df["entity_type"] == RNA],
         after_date,
         before_date,
         threshold=0.8,
@@ -592,7 +596,7 @@ def make_lowh_parquet_file(
     )
 
     dna_test_vs_train = get_lowh_by_mmseqs_seq_identity(
-        df[df["entity_type"] == RNA],
+        df[df["entity_type"] == DNA],
         after_date,
         before_date,
         threshold=0.8,

--- a/pxmeter/data/ccd.py
+++ b/pxmeter/data/ccd.py
@@ -48,7 +48,8 @@ def get_ccd_one_letter_code(res_name):
     Returns:
         str: The corresponding one-letter amino acid code if available, otherwise an empty string or None.
     """
-    one = get_from_ccd("chem_comp", res_name, "one_letter_code").as_item()
+    one = get_from_ccd("chem_comp", res_name, "one_letter_code")
+    one = None if one is None else one.as_item()
     return one
 
 


### PR DESCRIPTION
Minor pipeline fixes with no impact on output results:
1. Fix handling logic when CCD one-letter code is missing (None value)
2. Add guard for empty RNA test_vs_train.tsv file
3. Correct minor typos in DNA & RNA code blocks